### PR TITLE
New Load Colorization Strategy

### DIFF
--- a/RuneApp/App.config
+++ b/RuneApp/App.config
@@ -34,70 +34,79 @@
 	</startup>
 	<userSettings>
 		<RuneApp.Properties.Settings>
-			<setting name="SplitAssign" serializeAs="String">
-				<value>False</value>
-			</setting>
-			<setting name="StartUpHelp" serializeAs="String">
-				<value>True</value>
-			</setting>
-			<setting name="LockTest" serializeAs="String">
-				<value>False</value>
-			</setting>
-			<setting name="TestGray" serializeAs="String">
-				<value>True</value>
-			</setting>
-			<setting name="CheckUpdates" serializeAs="String">
-				<value>True</value>
-			</setting>
-			<setting name="UseEquipped" serializeAs="String">
-				<value>True</value>
-			</setting>
-			<setting name="TestGen" serializeAs="String">
-				<value>5000</value>
-			</setting>
-			<setting name="TestShow" serializeAs="String">
-				<value>100</value>
-			</setting>
-			<setting name="TestTime" serializeAs="String">
-				<value>20</value>
-			</setting>
-			<setting name="MakeStats" serializeAs="String">
-				<value>False</value>
-			</setting>
-			<setting name="ColorTeams" serializeAs="String">
-				<value>True</value>
-			</setting>
-			<setting name="InternalServer" serializeAs="String">
-				<value>False</value>
-			</setting>
-			<setting name="ShowBuildWizard" serializeAs="String">
-				<value>True</value>
-			</setting>
-			<setting name="SaveOneForLater" serializeAs="String">
-				<value>True</value>
-			</setting>
-			<setting name="SaveLocation" serializeAs="String">
-				<value/>
-			</setting>
-			<setting name="WatchSave" serializeAs="String">
-				<value>False</value>
-			</setting>
-			<setting name="UpgradeGrinds" serializeAs="String">
-				<value>True</value>
-			</setting>
-			<setting name="OnlyGrind6Legs" serializeAs="String">
-				<value>True</value>
-			</setting>
-			<setting name="UpgradeRequired" serializeAs="String">
-				<value>True</value>
-			</setting>
-			<setting name="ShowIreneOnStart" serializeAs="String">
-				<value>False</value>
-			</setting>
-			<setting name="IgnoreLess5" serializeAs="String">
-				<value>True</value>
-			</setting>
-		</RuneApp.Properties.Settings>
+   <setting name="SplitAssign" serializeAs="String">
+    <value>True</value>
+   </setting>
+   <setting name="StartUpHelp" serializeAs="String">
+    <value>False</value>
+   </setting>
+   <setting name="LockTest" serializeAs="String">
+    <value>False</value>
+   </setting>
+   <setting name="TestGray" serializeAs="String">
+    <value>True</value>
+   </setting>
+   <setting name="CheckUpdates" serializeAs="String">
+    <value>True</value>
+   </setting>
+   <setting name="UseEquipped" serializeAs="String">
+    <value>True</value>
+   </setting>
+   <setting name="TestGen" serializeAs="String">
+    <value>5000</value>
+   </setting>
+   <setting name="TestShow" serializeAs="String">
+    <value>100</value>
+   </setting>
+   <setting name="TestTime" serializeAs="String">
+    <value>20</value>
+   </setting>
+   <setting name="MakeStats" serializeAs="String">
+    <value>False</value>
+   </setting>
+   <setting name="ColorTeams" serializeAs="String">
+    <value>True</value>
+   </setting>
+   <setting name="InternalServer" serializeAs="String">
+    <value>False</value>
+   </setting>
+   <setting name="ShowBuildWizard" serializeAs="String">
+    <value>True</value>
+   </setting>
+   <setting name="SaveOneForLater" serializeAs="String">
+    <value>True</value>
+   </setting>
+   <setting name="SaveLocation" serializeAs="String">
+    <value />
+   </setting>
+   <setting name="WatchSave" serializeAs="String">
+    <value>False</value>
+   </setting>
+   <setting name="UpgradeGrinds" serializeAs="String">
+    <value>True</value>
+   </setting>
+   <setting name="OnlyGrind6Legs" serializeAs="String">
+    <value>True</value>
+   </setting>
+   <setting name="UpgradeRequired" serializeAs="String">
+    <value>True</value>
+   </setting>
+   <setting name="ShowIreneOnStart" serializeAs="String">
+    <value>False</value>
+   </setting>
+   <setting name="IgnoreLess5" serializeAs="String">
+    <value>False</value>
+   </setting>
+   <setting name="ColorLoadChanges" serializeAs="String">
+    <value>True</value>
+   </setting>
+   <setting name="ColorLoadUpgrades" serializeAs="String">
+    <value>True</value>
+   </setting>
+   <setting name="ColorLoadTimes" serializeAs="String">
+    <value>True</value>
+   </setting>
+  </RuneApp.Properties.Settings>
 	</userSettings>
 	<system.web>
 		<membership defaultProvider="ClientAuthenticationMembershipProvider">

--- a/RuneApp/Properties/Settings.Designer.cs
+++ b/RuneApp/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace RuneApp.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "14.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.1.0.0")]
     public sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -25,7 +25,7 @@ namespace RuneApp.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
         public bool SplitAssign {
             get {
                 return ((bool)(this["SplitAssign"]));
@@ -37,7 +37,7 @@ namespace RuneApp.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
         public bool StartUpHelp {
             get {
                 return ((bool)(this["StartUpHelp"]));
@@ -265,13 +265,49 @@ namespace RuneApp.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
         public bool IgnoreLess5 {
             get {
                 return ((bool)(this["IgnoreLess5"]));
             }
             set {
                 this["IgnoreLess5"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool ColorLoadChanges {
+            get {
+                return ((bool)(this["ColorLoadChanges"]));
+            }
+            set {
+                this["ColorLoadChanges"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool ColorLoadUpgrades {
+            get {
+                return ((bool)(this["ColorLoadUpgrades"]));
+            }
+            set {
+                this["ColorLoadUpgrades"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool ColorLoadTimes {
+            get {
+                return ((bool)(this["ColorLoadTimes"]));
+            }
+            set {
+                this["ColorLoadTimes"] = value;
             }
         }
     }

--- a/RuneApp/Properties/Settings.settings
+++ b/RuneApp/Properties/Settings.settings
@@ -3,10 +3,10 @@
   <Profiles />
   <Settings>
     <Setting Name="SplitAssign" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">False</Value>
+      <Value Profile="(Default)">True</Value>
     </Setting>
     <Setting Name="StartUpHelp" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">True</Value>
+      <Value Profile="(Default)">False</Value>
     </Setting>
     <Setting Name="LockTest" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
@@ -63,6 +63,15 @@
       <Value Profile="(Default)">False</Value>
     </Setting>
     <Setting Name="IgnoreLess5" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="ColorLoadChanges" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
+    <Setting Name="ColorLoadUpgrades" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
+    <Setting Name="ColorLoadTimes" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
   </Settings>


### PR DESCRIPTION
Font colors are hard to see so this converts (non-legacy) Loadout colorization to background colors.  All colors can now be controlled by a setting (no UI yet).  Closes #110.