### PR TITLE
Refactor Filtering Logic

### DIFF
--- a/RuneClasses/BuildProcessing/Build.Old.cs
+++ b/RuneClasses/BuildProcessing/Build.Old.cs
@@ -277,6 +277,7 @@ namespace RuneOptim.BuildProcessing {
                     }
                 }
                 // always try to put the current rune back in
+                /*
                 for (int i = 0; i < 6; i++) {
                     var r = Mon.Current.Runes[i];
                     if (r == null)
@@ -292,6 +293,7 @@ namespace RuneOptim.BuildProcessing {
                         Runes[i] = tl.ToArray();
                     }
                 }
+                */
 
                 Grinds = Runes.SelectMany(rg => rg.SelectMany(r => r.FilterGrinds(save.Crafts).Concat(r.FilterEnchants(save.Crafts)))).Distinct().ToArray();
             }

--- a/RuneClasses/BuildProcessing/Build.cs
+++ b/RuneClasses/BuildProcessing/Build.cs
@@ -1603,7 +1603,7 @@ namespace RuneOptim.BuildProcessing {
         }
 
         /// <summary>
-        /// Return the best increase of <paramref name="attr"/> of the subset of RuneSets <paramref name="maxSets"/>
+        /// Return the best increase of <paramref name="attr"/> from the possible RuneSets <paramref name="maxSets"/>
         /// </summary>
         /// <param name="attr"></param>
         /// <param name="maxSets"></param>
@@ -1660,6 +1660,12 @@ namespace RuneOptim.BuildProcessing {
             return 0;
         }
 
+        /// <summary>
+        /// Calculates the maximum number of each set that could be included based on the specific RequiredSets and BuildSets
+        /// </summary>
+        /// <param name="requiredSets"></param>
+        /// <param name="buildSets"></param>
+        /// <returns></returns>
         private Dictionary<RuneSet, int> GetMaxSetCount(IEnumerable<RuneSet> requiredSets, IEnumerable<RuneSet> buildSets)
         {
             Dictionary<RuneSet, int> setCounts = new Dictionary<RuneSet, int>();

--- a/RuneClasses/swar/Guild.cs
+++ b/RuneClasses/swar/Guild.cs
@@ -45,6 +45,31 @@ namespace RuneOptim.swar
         [JsonIgnore]
         public long Resistance => GuildInfo == null ? 0 : GuildInfo.Resistance;
 
+        public long ByStat(Attr attr)
+        {
+            switch (attr)
+            {
+                case Attr.HealthPercent:
+                    return Health;
+                case Attr.DefensePercent:
+                    return Defense;
+                case Attr.AttackPercent:
+                    return Attack;
+                case Attr.Speed:
+                    return Speed;
+                case Attr.CritRate:
+                    return CritRate;
+                case Attr.CritDamage:
+                    return CritDamage;
+                case Attr.Accuracy:
+                    return Accuracy;
+                case Attr.Resistance:
+                    return Resistance;
+                default:
+                    return 0;
+            }
+        }
+
     }
 
     public class GuildInfo


### PR DESCRIPTION
This was originally a branch to make the maximum bonus for the filtering logic RuneSet-aware (fixing #198).  Once I got into the logic for `cleanMinimum`, I realized that it needed fixed.  It seems to have included the RuneSet bonus twice *and* was missing Guild, Shrine, and Leader effects.  I rewrote (and documented) the existing approach to correctly incorporate these effects (plus the set-aware maximum bonuses).